### PR TITLE
Fix broken Stats table formatting in lunch/readme.md

### DIFF
--- a/lunch/readme.md
+++ b/lunch/readme.md
@@ -6,14 +6,14 @@
 
 ## The dish comes from Berkeley's beloved salad and soup joint, Mezzo. Attached the bar, Raleigh's, Mezzo is an unlikely place for a solid quick bite. 
 
-Field	Info
-Prep Time	20 minutes
-Cook Time	15 minutes (for bacon & chicken, if not pre-cooked)
-Total Time	35 minutes
-Servings	4 large salads
-Difficulty	Easy
-Tags	quick, high-protein, make-ahead, california-style, salad
-<!-- Note the fields in the markdown table -->
+| Field | Info |
+|---|---|
+| Prep Time | 20 minutes |
+| Cook Time | 15 minutes (for bacon & chicken, if not pre-cooked) |
+| Total Time | 35 minutes |
+| Servings | 4 large salads |
+| Difficulty | Easy |
+| Tags | quick, high-protein, make-ahead, california-style, salad |
 Ingredients:
 Salad Base
 
@@ -98,6 +98,6 @@ For a lighter version: Use all Greek yogurt and reduce the mayo by half.
 Serving style: This is meant to be a full meal salad, not a side.
 
 <!-- Optional: substitutions, tips, variations, or personal notes about the recipe. -->
-Author(s):
+Author(s): Jimmy Lin
 
 Recreated for home kitchens by ChatGPT, inspired by Berkeley deli tradition.


### PR DESCRIPTION
## Bug Description

The Stats section in `lunch/readme.md` (Mezzo Green Goddess Salad) was missing proper markdown table pipe (`|`) characters and a separator row (`|---|---|`). This caused the entire Stats block to render as plain unformatted text instead of a formatted table, making the recipe hard to read at a glance.

This PR fixes the bug reported in Issue #35, filed as part of Issue #16.

Closes #35

## Objective

Fix the broken Stats table in `lunch/readme.md` so it renders correctly as a markdown table, consistent with the format already used in `breakfast/readme.md` and `dinner/readme.md`.

## Changes Made

- Replaced the plain-text stats block (lines 9-16) with a properly formatted markdown table using `| Field | Info |` syntax and `|---|---|` separator row
- Added `Jimmy Lin` to the `Author(s):` section as required for contributor tracking


@jamestakami  and @marthafu  — please review and approve when ready so this can be merged. Two approvals required before merging per team rules.